### PR TITLE
Revert "common.c: Fix errors in debug output for function"

### DIFF
--- a/src/common.c
+++ b/src/common.c
@@ -284,15 +284,14 @@ common_add_module(const char *file, uint64_t fsize)
         return BF_ERROR_MAX_MODULES_REACHED;
     }
 
-    struct bfelf_binary_t *new_module = &g_modules[g_num_modules];
-    new_module->file = file;
-    new_module->file_size = fsize;
+    g_modules[g_num_modules].file = file;
+    g_modules[g_num_modules].file_size = fsize;
 
-    BFDEBUG("common_add_module [%ld]:\n", g_num_modules);
-    BFDEBUG("    addr = %p\n", (void*)new_module);
-    BFDEBUG("    size = %lu\n", fsize);
+    BFDEBUG("common_add_module [%d]:\n", (int)g_num_modules);
+    BFDEBUG("    addr = %p\n", (void *)file);
+    BFDEBUG("    size = %p\n", (void *)fsize);
 
-    ++g_num_modules;
+    g_num_modules++;
     return BF_SUCCESS;
 }
 


### PR DESCRIPTION
Reverts Bareflank/bfdriver#5

After compiling this code, I realized why the print statement is written this way as the Linux and Windows kernel / userspace testing do not agree on the use of the format specifiers in this PR. Also, the `(void *)` for `file` prints the location in memory of the module. Although this is useful, the original code / intent was to print the `exec` not the `file` location so that you can reverse a backtrace to figure out which line in a module caused a kernel panic. For now the original code compiles better with the different environments we have to support, but it should be moved so that we can see the `exec` and not the `file` location in memory which I will do later. 

